### PR TITLE
Create space for H1 at top of document

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -11,6 +11,10 @@
   .gutter,
   .scroll-view {
     padding-top: 4px; //create space for H1 at top of document
+    .line-number-0 {
+      padding-top: 4px;
+      top: -4px !important; //overrule inline style  
+    }
   }
 
   .wrap-guide {

--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -8,6 +8,11 @@
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
+  .gutter,
+  .scroll-view {
+    padding-top: 4px; //create space for H1 at top of document
+  }
+
   .wrap-guide {
     background-color: @syntax-wrap-guide-color;
   }

--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -8,15 +8,6 @@
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
-  .gutter,
-  .scroll-view {
-    padding-top: 4px; //create space for H1 at top of document
-    .line-number-0 {
-      padding-top: 4px;
-      top: -4px !important; //overrule inline style  
-    }
-  }
-
   .wrap-guide {
     background-color: @syntax-wrap-guide-color;
   }
@@ -285,6 +276,21 @@
 
 .none {
   color: @syntax-text-color;
+}
+
+
+//create space for H1 at top of document
+atom-text-editor:not(.mini),
+atom-text-editor:not(.mini)::shadow{
+    .gutter,
+    .scroll-view {
+      padding-top: 4px;
+      .line-number-0 {
+        padding-top: 4px;
+        top: -4px !important; //overrule inline style
+      }
+
+  }
 }
 
 


### PR DESCRIPTION
Might be a fix for #2. A bit of padding on the gutter and scroll-view elements creates room for the larger headings. 

before:
![before](https://cloud.githubusercontent.com/assets/2543659/5709291/f8b85508-9a98-11e4-8f55-9ae2db2228ea.png)

after:
![after](https://cloud.githubusercontent.com/assets/2543659/5709292/f8db3262-9a98-11e4-872c-6f4a5179b6bf.png)
