### PR TITLE
Added language-pfm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "theme": "syntax",
   "version": "0.3.6",
   "description": "A syntax theme specifically for writing papers in markdown. Featuring a paper like color scheme and increased font-size for headings",
-  "repository": "https://github.com/leipert/pen-paper-coffee-syntax",
+  "repository": "https://github.com/nylki/pen-paper-coffee-syntax",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "theme": "syntax",
   "version": "0.3.6",
   "description": "A syntax theme specifically for writing papers in markdown. Featuring a paper like color scheme and increased font-size for headings",
-  "repository": "https://github.com/nylki/pen-paper-coffee-syntax",
+  "repository": "https://github.com/leipert/pen-paper-coffee-syntax",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"

--- a/sample documents/markdown_sample.md
+++ b/sample documents/markdown_sample.md
@@ -37,4 +37,68 @@ On her way she met a copy. The copy warned the Little Blind Text, that where it 
 Separated they live in Bookmarksgrove right at the coast of the Semantics, a large language ocean. A small river named Duden flows by their place and supplies it with the necessary regelialia. It is a paradisematic country, in which roasted parts of sentences fly into your mouth. Even the all-powerful Pointing has no control about the blind texts it is an almost unorthographic life One day however a small line of blind text by the name of Lorem Ipsum decided to leave for the far World of Grammar. The Big Oxmox advised her not to do so, because there were thousands of bad Commas, wild Question Marks and devious Semikoli, but the Little Blind Text didn’t listen. She packed her seven versalia, put her initial into the belt and made herself on the way. When she reached the first hills of the Italic Mountains, she had a last view back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet Village and the subline of her own road, the Line Lane. Pityful a rethoric question ran over her cheek, then she continued her way. On her way she met a copy. The copy warned the Little Blind Text, that where it came from it would have been rewritten a thousand times and everything that was left from its origin would be the word "and" and the Little Blind Text should turn around
 
 
-# pandoc tests
+## pandoc tests
+
+The following tests should work if you use the atom [language-pfm](https://atom.io/packages/language-pfm)
+
+### Math
+
+**The following should work**
+
+Inline math should look really nice, whether with `$...$` $x \subset y$ or `\(...\)` \(x \cap y \)
+
+But also as math blocks with `$$...$$` or `\[...\`:
+
+$$
+x \subset y\\
+x = y
+$$
+
+\[ E = mc^2 \]
+
+$$ E = mc^2 $$
+
+**The following are not math**
+
+There should be no space between the dollar sign and the inline-math.
+
+$ x \subset y$
+
+$x \subset y $
+
+### Inline HTML
+
+<div class="foobar">
+<ul>
+<li>**Markdown works in inline html**</li>
+<li>
+~~Markdown works in inline html~~
+</li>
+</ul>
+</div>
+
+### Definition Lists
+
+Long definition with `:` syntax:
+
+bar
+:   Is a short definition
+
+~~foobar~~
+:   Is a mixture of
+
+    1. foo
+    ```
+    var x = y;
+    a
+    ```
+    2. **bar**
+
+Short definition with `~` syntax:
+
+Term 2
+  ~ Definition 2a
+
+    Definition 2b
+
+Definitions ends before that line

--- a/stylesheets/languages/markdown.less
+++ b/stylesheets/languages/markdown.less
@@ -121,3 +121,21 @@
   color: @list-color;
   font-weight: bold;
 }
+
+.pfm.math {
+
+  .gfm.support {
+    color: darken(@green, 10%);
+  }
+
+  background: lighten(@green,50%);
+  color: @green;
+}
+
+.pfm.definition {
+  background: lighten(@blue,30%);
+
+    .leading-whitespace{
+      background: lighten(@blue,30%);
+  }
+}


### PR DESCRIPTION
Implemented theme support for Pandoc Markdown [language-pfm](https://atom.io/packages/language-pfm)

* Mathsyntax with inline `$...$` and `\(...\)` and block `$$...$$` and `\[...\]` (Issue: #10)
* [Definition Lists]

Please note that the nested colors in math mode come from `language-latex`

[Definition Lists]: http://johnmacfarlane.net/pandoc/README.html#extension-definition_lists

**A little preview**:

![screen shot 2015-03-13 at 23 17 38](https://cloud.githubusercontent.com/assets/2906107/6648193/3e8003de-c9d7-11e4-815c-a0f20fe3e996.png)
![screen shot 2015-03-13 at 23 17 57](https://cloud.githubusercontent.com/assets/2906107/6648194/3e8079ae-c9d7-11e4-9d47-739f14df1bf3.png)

